### PR TITLE
Support RVV 0.7.1 using GCC 14+

### DIFF
--- a/src/softmax/Makefile
+++ b/src/softmax/Makefile
@@ -4,9 +4,18 @@
 # available options (the version used must support RVV intrinsics)
 # clang/llvm
 RISCVCLANG=clang  --target=riscv64
-# RISCVCC=clang  --target=riscv64
+
 # GNU Compiler Collection (GCC)
-RISCVCC=riscv64-unknown-elf-gcc 
+RISCVGCC=riscv64-unknown-elf-gcc
+
+#RISCVCCV=$(RISCVCLANG)
+RISCVCCV=$(RISCVGCC)
+RISCVCC=$(RISCVGCC) 
+
+OPT=-O2
+
+#RVV=v
+RVV=_xtheadvector
 
 EXTRA_CFLAGS?=-DCOUNT_INSTRET
 
@@ -23,18 +32,19 @@ SIMULATOR=spike --isa=rv64gcv_zicntr_zihpm --varch=vlen:$(VLEN),elen:64 $(PK_PAT
 # SIMULATOR=qemu-riscv64 -cpu rv64,v=on,vext_spec=v1.0,vlen=128,rvv_ta_all_1s=on
 
 INCLUDE_DIR ?= /opt/riscv/riscv64-unknown-elf/include/
+# INCLUDE=-I$(INCLUDE_DIR)
 
 softmax_baseline.o: softmax_baseline.c
-	$(RISCVCLANG) $(EXTRA_CFLAGS) -I./ -I$(INCLUDE_DIR)  -O2 -march=rv64gcv -c -o $@ $^
+	$(RISCVCCV) $(EXTRA_CFLAGS) -I./ $(INCLUDE)  $(OPT) -march=rv64gc$(RVV) -c -o $@ $^
 
 softmax_rvv.o: softmax_rvv.c
-	$(RISCVCLANG) $(EXTRA_CFLAGS) -I./ -I$(INCLUDE_DIR)  -O2 -march=rv64gcv -c -o $@ $^
+	$(RISCVCCV) $(EXTRA_CFLAGS) -I./ $(INCLUDE)  $(OPT) -march=rv64gc$(RVV) -c -o $@ $^
 
 bench_softmax: bench_softmax.c softmax_baseline.o softmax_rvv.o
-	 $(RISCVCC) $(EXTRA_CFLAGS) -I./ -O2 -march=rv64gcv $^ -lm -o $@
+	 $(RISCVCC) $(EXTRA_CFLAGS) -I./ $(OPT) -march=rv64gc $^ -lm -o $@
 
 bench_exp: bench_expf.c softmax_baseline.o softmax_rvv.o
-	 $(RISCVCC) $(EXTRA_CFLAGS) -I./ -O2 -march=rv64gcv $^ -lm -o $@
+	 $(RISCVCC) $(EXTRA_CFLAGS) -I./ $(OPT) -march=rv64gc $^ -lm -o $@
 
 sim_bench_softmax: bench_softmax
 	$(SIMULATOR) $^

--- a/src/softmax/bench_softmax.c
+++ b/src/softmax/bench_softmax.c
@@ -128,7 +128,7 @@ int main(void) {
             printf("  error norm 2:       %.4a\n", bench_result.error_norm2);
 #           else
             // condensed display
-            printf("%s, %d, %d, %.3e, %.3e, %.3e %.3e\n", 
+            printf("%s, %ld, %ld, %.3e, %.3e, %.3e %.3e\n",
                    benchmarks[benchId].label, n, bench_result.perf_count,
                    bench_result.max_abs_error, bench_result.max_rel_error, bench_result.error_norm2, bench_result.mean_rel_error);
 #           endif


### PR DESCRIPTION
GCC 14 supports generating code for RVV 0.7.1 (under the name xtheadvector) from unmodified RVV intrinsics calls.

Tested on LicheePi 4A, C910 core.

Of course you should change the Makefile defaults back to how you like them. This is just as I built it.